### PR TITLE
RISK-20: Remove initialAmountInUSD as required param

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,6 @@ PRIVATE_KEY=
 RISK_API_KEY=
 # ID of the portfolio you're creating (e.g., "main-portfolio")
 PORTFOLIO_ID=
-# Initial amount in USD to start the portfolio (number)
-INITIAL_AMOUNT_IN_USD=
 # URL or IP address of the current server where the code is running
 SERVER_URL=
 
@@ -23,6 +21,8 @@ RPC_URL=
 PORTFOLIO_NAME=
 # (optional) Chain ID (defaults to 42161, Arbitrum One)
 CHAIN_ID=
+# (optional) Initial amount in USD to start the portfolio (defaults to total amount of USDC in wallet)
+INITIAL_AMOUNT_IN_USD=
 # (optional) Maximum risk score (defaults to 3.75)
 MAX_RISK_SCORE=
 # (optional) Rebalance frequency in hours (defaults to 1)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ The app reads environment variables from a `.env` file. See `.env.example` for f
 - `PRIVATE_KEY` – Your portfolio’s main wallet private key. **Note**: The wallet must have [USDC on Arbitrum](https://arbiscan.io/token/0xaf88d065e77c8cc2239327c5edb3a432268e5831).
 - `RISK_API_KEY` – Your unique organization API key for Stay Liquid’s Risk API. If you don’t have one, request it from our team.
 - `PORTFOLIO_ID` – The ID of the portfolio you’ll be creating. Can be any string, dashes allowed (e.g., "main-portfolio").
-- `INITIAL_AMOUNT_IN_USD` – Starting portfolio amount, in number of USDC tokens. Minimum is 10,000.
 - `SERVER_URL` – URL or IP address of the server where this code is running (e.g., `1.1.1.1`, `http://1.1.1.1`, or `https://yourdomain.com`)
 
 ### Optional (with defaults)

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,10 @@ module.exports = {
     serverUrl: process.env.SERVER_URL,
     minNumPositions: Number(process.env.MIN_NUM_POSITIONS) || 3,
     maxNumPositions: Number(process.env.MAX_NUM_POSITIONS) || 3,
-    initialAmountInUSD: Number(process.env.INITIAL_AMOUNT_IN_USD),
+    initialAmountInUSD:
+      process.env.INITIAL_AMOUNT_IN_USD 
+      ? Number(process.env.INITIAL_AMOUNT_IN_USD) 
+      : undefined,
     mainAssetAddr:
       process.env.MAIN_ASSET_ADDR ||
       "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC on Arbitrum

--- a/src/index.js
+++ b/src/index.js
@@ -60,14 +60,17 @@ const createPortfolio = async (apiUrl, portfolio) => {
       walletAddr: portfolio.walletAddr,
       mainAssetAddr: portfolio.mainAssetAddr,
     };
+    const cleanParams = Object.fromEntries(
+      Object.entries(params).filter(([_, v]) => v !== undefined)
+    );
     console.log(
       chalk.cyan.bold("📊 Creating portfolio with parameters:"),
       "\n",
       chalk.magenta("Parameters:"),
-      params
+      cleanParams,
     );
 
-    const query = new URLSearchParams(params).toString();
+    const query = new URLSearchParams(cleanParams).toString();
     const response = await axios.post(
       `${apiUrl}/portfolio/create?${query}`,
       {},


### PR DESCRIPTION
Tested with leaving param out and moving 1 more USDC into wallet, thus creating portfolios with 10 and 11 balance respectively (automatically).

<img width="233" alt="image" src="https://github.com/user-attachments/assets/b626c88c-37c5-4df8-b32a-4cbdc429ac43" />
<img width="221" alt="image" src="https://github.com/user-attachments/assets/52da3c6f-12f8-4bee-b367-11673fdc6e55" />

This config variable uses ternary operator to respect 0 as a possible input - hence the need to filter out undefined parameters in `src/index.js`